### PR TITLE
Fixing a broken link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ The result text processed by this Speech-to-Text API is then returned just like 
 
 Optimist Bot receives commands from users as both text and voice input, and understands commands in natural language. 
 
-This is done by using the `pattern` NLP [library](www.clips.ua.ac.be/pages/pattern-en), which allows the bot to deconstruct the user's text input and recognize parts of speech. For now, the model for categorizing commands are simple with stopwords and sentence structures, but as our data grows, we can start building more complex machine learning categorization for each function.
+This is done by using the `pattern` NLP [library](http://www.clips.ua.ac.be/pages/pattern-en), which allows the bot to deconstruct the user's text input and recognize parts of speech. For now, the model for categorizing commands are simple with stopwords and sentence structures, but as our data grows, we can start building more complex machine learning categorization for each function.
 
 The command system allows users to use the following features, all of which are under the `Utils` folder.
 


### PR DESCRIPTION
The NLP pattern library link wasn't working - added a http:// to the front so it didn't try and make it local to the project